### PR TITLE
test: fix sample detail and edit tests

### DIFF
--- a/src/js/samples/components/Detail/__tests__/SampleDetailGeneral.test.tsx
+++ b/src/js/samples/components/Detail/__tests__/SampleDetailGeneral.test.tsx
@@ -1,10 +1,10 @@
-import { screen } from "@testing-library/react";
+import Samples from "@samples/components/Samples";
+import { screen, waitFor } from "@testing-library/react";
 import { createFakeSample, mockApiGetSampleDetail } from "@tests/fake/samples";
 import { renderWithMemoryRouter } from "@tests/setupTests";
 import numbro from "numbro";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import SampleDetailGeneral from "../SampleDetailGeneral";
 
 describe("<SampleDetailGeneral />", () => {
     let props;
@@ -12,16 +12,14 @@ describe("<SampleDetailGeneral />", () => {
 
     beforeEach(() => {
         sample = createFakeSample({ paired: true });
-        props = {
-            match: { params: { sampleId: sample.id } },
-        };
     });
 
     it("should render properly when data is installing", async () => {
         const unreadySample = createFakeSample({ paired: true, ready: false });
-        props.match.params.sampleId = unreadySample.id;
         const scope = mockApiGetSampleDetail(unreadySample);
-        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
+        renderWithMemoryRouter(<Samples />, [`/samples/${unreadySample.id}`]);
+
+        await waitFor(() => scope.done());
 
         expect(await screen.findByText("Metadata")).toBeInTheDocument();
 
@@ -45,7 +43,7 @@ describe("<SampleDetailGeneral />", () => {
 
     it("should render properly", async () => {
         const scope = mockApiGetSampleDetail(sample);
-        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
+        renderWithMemoryRouter(<Samples />, [`/samples/${sample.id}`]);
 
         expect(await screen.findByText("Metadata")).toBeInTheDocument();
 
@@ -81,7 +79,7 @@ describe("<SampleDetailGeneral />", () => {
 
     it("should render with [paired=true]", async () => {
         const scope = mockApiGetSampleDetail(sample);
-        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
+        renderWithMemoryRouter(<Samples />, [`/samples/${sample.id}`]);
 
         expect(await screen.findByText("Paired")).toBeInTheDocument();
         expect(screen.getByText("Yes")).toBeInTheDocument();
@@ -91,9 +89,8 @@ describe("<SampleDetailGeneral />", () => {
 
     it("should render with [paired=false]", async () => {
         sample = createFakeSample({ paired: false });
-        props.match.params.sampleId = sample.id;
         const scope = mockApiGetSampleDetail(sample);
-        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
+        renderWithMemoryRouter(<Samples />, [`/samples/${sample.id}`]);
 
         expect(await screen.findByText("Paired")).toBeInTheDocument();
         expect(screen.getByText("No")).toBeInTheDocument();

--- a/src/js/samples/components/__tests__/EditSample.test.tsx
+++ b/src/js/samples/components/__tests__/EditSample.test.tsx
@@ -1,10 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom-v5-compat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createFakeSample, mockApiEditSample } from "../../../../tests/fake/samples";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import EditSample from "../EditSample";
 
 describe("<Editsample />", () => {
@@ -22,13 +21,7 @@ describe("<Editsample />", () => {
     it("should render when [show=false]", () => {
         props.show = false;
 
-        renderWithRouter(
-            <MemoryRouter initialEntries={["/"]}>
-                <Routes>
-                    <Route path="samples/:id/general" element={<EditSample {...props} />} />
-                </Routes>
-            </MemoryRouter>
-        );
+        renderWithMemoryRouter(<EditSample {...props} />);
 
         expect(screen.queryByRole("textbox", { name: "Name" })).toBeNull();
         expect(screen.queryByRole("textbox", { name: "Isolate" })).toBeNull();
@@ -39,13 +32,7 @@ describe("<Editsample />", () => {
     });
 
     it.each(["Name", "Isolate", "Host", "Locale", "Notes"])("should render changed data for", async inputLabel => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={["/"]}>
-                <Routes>
-                    <Route path="samples/:id/general" element={<EditSample {...props} />} />
-                </Routes>
-            </MemoryRouter>
-        );
+        renderWithMemoryRouter(<EditSample {...props} />);
 
         const inputBox = screen.getByLabelText(inputLabel);
         expect(inputBox).toBeInTheDocument();
@@ -60,13 +47,7 @@ describe("<Editsample />", () => {
 
     it("should update sample when form is submitted", async () => {
         const scope = mockApiEditSample(sample, "newName", "newIsolate", "newHost", "newLocale", "newNotes");
-        renderWithRouter(
-            <MemoryRouter initialEntries={["/"]}>
-                <Routes>
-                    <Route path="samples/:id/general" element={<EditSample {...props} />} />
-                </Routes>
-            </MemoryRouter>
-        );
+        renderWithMemoryRouter(<EditSample {...props} />);
 
         const nameInput = screen.getByLabelText("Name");
         await userEvent.clear(nameInput);


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Fixes both test types:

Edit sample:
 - Simplified the router statement and it worked as expected. Not sure what the original issue was here

SampleDetail:
 - The update to v6 means that location now comes from a hook. As a result we can't just inject a fake match as props. Solution was just to start the test one component up and provide the correct route to match the id
